### PR TITLE
homework-3.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module find-duplicates
 
 go 1.16
+
+require github.com/sirupsen/logrus v1.8.1

--- a/main.go
+++ b/main.go
@@ -5,11 +5,10 @@ import (
 	"find-duplicates/set"
 	"flag"
 	"fmt"
+	log "github.com/sirupsen/logrus"
 	"io"
 	"io/ioutil"
-	"log"
 	"os"
-	"runtime"
 	"sync"
 )
 
@@ -20,11 +19,22 @@ var (
 	dirsWG       = new(sync.WaitGroup)
 	stop         = make(chan struct{}, 1)
 	files_buffer = 100
+	logLevel     *uint
+	logger       *log.Logger
 )
 
 func init() {
+	logLevelUsage := "Logging level:"
+	for _, level := range log.AllLevels {
+		logLevelUsage = logLevelUsage + fmt.Sprintf("\n\t%d - %s", level, level.String())
+	}
 	path = flag.String("path", "data", "path to the directory where duplicates will be searched")
+	logLevel = flag.Uint("log_level", 1, logLevelUsage)
 	flag.Parse()
+	log.SetFormatter(&log.JSONFormatter{})
+	log.SetOutput(os.Stdout)
+	log.SetLevel(log.Level(*logLevel))
+	logger = log.StandardLogger()
 }
 
 func main() {
@@ -32,6 +42,9 @@ func main() {
 	dirsDone := make(chan struct{}, 1)
 	filesDone := make(chan struct{}, 1)
 	errors := make(chan error, 1)
+	fields := log.Fields{
+		"function": "main",
+	}
 	defer func() {
 		close(fileNames)
 		close(dirsDone)
@@ -43,43 +56,40 @@ func main() {
 	go RunFiles(fileNames, errors, dirsDone, filesDone)
 
 	go func() {
-		for true {
-			select {
-			case err := <-errors:
-				if err != nil {
-					log.Printf("error: %+v", err)
-					stop <- struct{}{}
-				}
-			default:
-				runtime.Gosched()
+		select {
+		case err := <-errors:
+			if err != nil {
+				logger.WithFields(fields).Errorf("error: %+v", err)
+				stop <- struct{}{}
 			}
+		case <-filesDone:
+			logger.WithFields(fields).Debug("all files have been processed")
+			filesDone <- struct{}{}
 		}
 	}()
 	dirsWG.Wait()
-	fmt.Println("Dirs done!")
+	logger.WithFields(fields).Debug("dirs done")
 	dirsDone <- struct{}{}
-Loop:
-	for true {
-		select {
-		case <-stop:
-			fmt.Println("Loop, stop")
-			stop <- struct{}{}
-			return
-		case <-filesDone:
-			fmt.Println("Loop, break")
-			break Loop
-		default:
-			runtime.Gosched()
-		}
+	select {
+	case <-stop:
+		logger.WithFields(fields).Debug("stop signal received")
+		stop <- struct{}{}
+		return
+	case <-filesDone:
+		logger.WithFields(fields).Debug("all files have been processed")
 	}
 	duplicates.Print()
 }
 
 func ReadDir(dirName string, fileNames chan string, errors chan error) {
 	defer dirsWG.Done()
+	fields := log.Fields{
+		"function": "ReadDir",
+		"path":     dirName,
+	}
 	select {
 	case <-stop:
-		fmt.Println("ReadDir, stop", dirName)
+		logger.WithFields(fields).Debug("stop signal received")
 		stop <- struct{}{}
 		return
 	default:
@@ -97,7 +107,7 @@ func ReadDir(dirName string, fileNames chan string, errors chan error) {
 				location := dirName + string(os.PathSeparator) + fi.Name()
 				select {
 				case <-stop:
-					fmt.Println("ReadDir, stop", dirName)
+					logger.WithFields(fields).Debug("stop signal received")
 					stop <- struct{}{}
 				default:
 					fileNames <- location
@@ -110,29 +120,38 @@ func ReadDir(dirName string, fileNames chan string, errors chan error) {
 
 func RunFiles(fileNames chan string, errors chan error, dirsDone chan struct{}, filesDone chan struct{}) {
 	wg := sync.WaitGroup{}
+	fields := log.Fields{
+		"function": "RunFiles",
+	}
 Loop:
 	for true {
 		select {
 		case <-stop:
-			fmt.Println("RunFiles, stop")
+			logger.WithFields(fields).Debug("stop signal received")
 			stop <- struct{}{}
 			return
 		case location := <-fileNames:
+			logger.WithFields(fields).WithField("file", location).Info("file has been submitted for processing")
 			wg.Add(1)
 			go HashFile(location, &wg, errors)
 		case <-dirsDone:
+			logger.WithFields(fields).Debug("all files have been submitted for processing")
 			break Loop
-		default:
-			runtime.Gosched()
 		}
 	}
 	wg.Wait()
+	logger.WithFields(fields).Debug("all files have been processed")
 	filesDone <- struct{}{}
 }
 
 func HashFile(location string, wg *sync.WaitGroup, errors chan error) {
 	defer wg.Done()
 	f, err := os.Open(location)
+	fileds := log.Fields{
+		"path":     location,
+		"function": "HashFile",
+	}
+	logger.WithFields(fileds).Info("started parsing the file")
 	if err != nil {
 		errors <- err
 		return
@@ -146,6 +165,7 @@ func HashFile(location string, wg *sync.WaitGroup, errors chan error) {
 	key := fmt.Sprintf("%x", h.Sum(nil))
 	//fmt.Println(key, location)
 	if fileHashes.Has(key) {
+		logger.WithFields(fileds).Debug("the file is a duplicate")
 		if duplicates.Has(key) {
 			duplicates.Append(key, location)
 		} else {
@@ -153,6 +173,7 @@ func HashFile(location string, wg *sync.WaitGroup, errors chan error) {
 			duplicates.Add(key, []string{oldLocation, location})
 		}
 	} else {
+		logger.WithFields(fileds).Debug("the file is currently unique")
 		fileHashes.Add(key, location)
 	}
 }


### PR DESCRIPTION
Добавьте в программу для поиска дубликатов, разработанную в рамках проектной работы на предыдущем модуле логи.
1) Необходимо использовать пакет zap или logrus.
2) Разграничить уровни логирования.
3) Обогатить параметрами по вашему усмотрению.
4) Вставить вызов panic() в участке коде, в котором осуществляется переход в поддиректорию; удостовериться, что по логам можно локализовать при каком именно переходе в какую директорию сработала паника.
